### PR TITLE
Feature/pontuar equipes

### DIFF
--- a/gincana/gincana-entity/src/main/java/ifsul/gincana/entity/entities/Prova.java
+++ b/gincana/gincana-entity/src/main/java/ifsul/gincana/entity/entities/Prova.java
@@ -64,6 +64,19 @@ public class Prova implements Serializable {
     @ManyToOne(cascade = ALL)
     @JoinColumn(name = "id_edicao")
     private Edicao edicao;
+    
+    @NotNull
+    @Basic(optional = false)
+    @Column(name = "pontuada")
+    private Boolean pontuada;
+
+    public Boolean getPontuada() {
+        return pontuada;
+    }
+
+    public void setPontuada(Boolean pontuada) {
+        this.pontuada = pontuada;
+    }
 
     public Long getId() {
         return id;

--- a/gincana/gincana-service/src/main/java/ifsul/gincana/service/repositories/ProvaRepository.java
+++ b/gincana/gincana-service/src/main/java/ifsul/gincana/service/repositories/ProvaRepository.java
@@ -1,6 +1,9 @@
 package ifsul.gincana.service.repositories;
 
 import ifsul.gincana.entity.entities.Prova;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 /**
@@ -9,5 +12,6 @@ import org.springframework.data.repository.PagingAndSortingRepository;
  */
 public interface ProvaRepository extends PagingAndSortingRepository<Prova, Long> {
 
-
+    @Query("SELECT p FROM Prova AS p WHERE p.pontuada = false")
+    public Page<Prova> findAllNotScored(Pageable page);
 }

--- a/gincana/gincana-service/src/main/java/ifsul/gincana/service/services/ProvaService.java
+++ b/gincana/gincana-service/src/main/java/ifsul/gincana/service/services/ProvaService.java
@@ -28,4 +28,8 @@ public class ProvaService {
     public Page<Prova> findAll(Pageable pgbl) {
         return repository.findAll(pgbl);
     }
+    
+    public Page<Prova> findAllNotScored(Pageable pgbl) {
+        return repository.findAllNotScored(pgbl);
+    }
 }

--- a/gincana/gincana-web/src/main/java/ifsul/gincana/controllers/ProvaController.java
+++ b/gincana/gincana-web/src/main/java/ifsul/gincana/controllers/ProvaController.java
@@ -38,7 +38,7 @@ public class ProvaController {
     @RequestMapping(value = "/provas", method = RequestMethod.GET)
     public String provas(Model model, Pageable pgbl) {
         Usuario usuario = usuarioUtil.getUsuario();
-        Page<Prova> provas = provaService.findAll(pgbl);
+        Page<Prova> provas = provaService.findAllNotScored(pgbl);
         Page<Equipe> equipes = equipeService.findAll(pgbl);
 
         model.addAttribute("usuario", usuario);


### PR DESCRIPTION
Para simplificar as coisas, na tela de pontuação de equipes exibimos apenas as provas que ainda não foram pontuadas. Depois pensamos em uma tela com todas as tabelas, possibilitando a edição da pontuação. Para essa feature adicionei um atributo estado para verificar se a prova já foi devidamente pontuada.